### PR TITLE
fix: Add Trade and Coupon data to events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage/
 lcov.info
 
 .gas-snapshot
+.gas-report

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ docs/
 
 coverage/
 lcov.info
+
+.gas-snapshot

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,7 @@ coverage/
 lcov.info
 
 .gas-snapshot
+.gas-snapshot.diff
+
 .gas-report
+.gas-report.diff

--- a/src/coupons/CouponManager.sol
+++ b/src/coupons/CouponManager.sol
@@ -23,7 +23,7 @@ contract CouponManager is Verifications, CouponTypesHashing, MarketplaceTypes {
 
     event MarketplaceUpdated(address indexed _caller, address indexed _marketplace);
     event AllowedCouponsUpdated(address indexed _caller, address indexed _coupon, bool _value);
-    event CouponApplied(address indexed _caller, bytes32 indexed _tradeSignature, bytes32 indexed _couponSignature);
+    event CouponApplied(address indexed _caller, bytes32 indexed _tradeSignature, bytes32 indexed _couponSignature, Coupon _coupon);
 
     error LengthMissmatch();
     error UnauthorizedCaller(address _caller);
@@ -100,7 +100,7 @@ contract CouponManager is Verifications, CouponTypesHashing, MarketplaceTypes {
         // Verify that the Coupon signature is valid.
         _verifyCouponSignature(_coupon, signer);
 
-        emit CouponApplied(caller, hashedTradeSignature, hashedCouponSignature);
+        emit CouponApplied(caller, hashedTradeSignature, hashedCouponSignature, _coupon);
 
         // Increase the amount of uses of the Coupon signature.
         signatureUses[hashedCouponSignature]++;

--- a/src/marketplace/Marketplace.sol
+++ b/src/marketplace/Marketplace.sol
@@ -83,10 +83,10 @@ abstract contract Marketplace is Verifications, MarketplaceTypesHashing, Pausabl
         bytes32 hashedSignature = keccak256(_trade.signature);
         address signer = _trade.signer;
 
-        emit Traded(_caller, hashedSignature, _trade);
-
         _transferAssets(_trade.sent, signer, _caller, signer, _caller);
         _transferAssets(_trade.received, _caller, signer, signer, _caller);
+
+        emit Traded(_caller, hashedSignature, _trade);
     }
 
     /// @dev Verifies that the Trade passes all checks and the signature is valid.

--- a/src/marketplace/Marketplace.sol
+++ b/src/marketplace/Marketplace.sol
@@ -15,7 +15,7 @@ abstract contract Marketplace is Verifications, MarketplaceTypesHashing, Pausabl
     mapping(bytes32 => bool) public usedTradeIds;
 
     /// @dev The event is emitted with the hashed signature so it can be identified off chain.
-    event Traded(address indexed _caller, bytes32 indexed _signature);
+    event Traded(address indexed _caller, bytes32 indexed _signature, Trade _trade);
 
     error UsedTradeId();
 
@@ -83,7 +83,7 @@ abstract contract Marketplace is Verifications, MarketplaceTypesHashing, Pausabl
         bytes32 hashedSignature = keccak256(_trade.signature);
         address signer = _trade.signer;
 
-        emit Traded(_caller, hashedSignature);
+        emit Traded(_caller, hashedSignature, _trade);
 
         _transferAssets(_trade.sent, signer, _caller, signer, _caller);
         _transferAssets(_trade.received, _caller, signer, signer, _caller);

--- a/test/coupons/CouponManager.t.sol
+++ b/test/coupons/CouponManager.t.sol
@@ -123,7 +123,7 @@ contract UpdateAllowedCouponsTests is CouponsTests {
 }
 
 contract ApplyCouponTests is CouponsTests {
-    event CouponApplied(address indexed _caller, bytes32 indexed _tradeSignature, bytes32 indexed _couponSignature);
+    event CouponApplied(address indexed _caller, bytes32 indexed _tradeSignature, bytes32 indexed _couponSignature, CouponManagerHarness.Coupon _coupon);
 
     error UnauthorizedCaller(address _caller);
     error CouponNotAllowed(address _coupon);
@@ -204,7 +204,7 @@ contract ApplyCouponTests is CouponsTests {
 
         vm.prank(marketplace);
         vm.expectEmit(address(couponManager));
-        emit CouponApplied(marketplace, keccak256(trade.signature), keccak256(coupon.signature));
+        emit CouponApplied(marketplace, keccak256(trade.signature), keccak256(coupon.signature), coupon);
         CouponManagerHarness.Trade memory updatedTrade = couponManager.applyCoupon(trade, coupon);
         // Mock coupon implementation updates the signer of the trade to address(1337).
         assertEq(updatedTrade.signer, address(1337));

--- a/test/coupons/CouponManager.t.sol
+++ b/test/coupons/CouponManager.t.sol
@@ -212,7 +212,7 @@ contract ApplyCouponTests is CouponsTests {
     }
 }
 
-contract CancelSignatureTests is CouponsTests {
+contract CancelSignatureTestsCouponManager is CouponsTests {
     event SignatureCancelled(address indexed _caller, bytes32 indexed _signature);
 
     function test_CanSendEmptyListOfCoupons() public {

--- a/test/marketplace/DecentralandMarketplaceEthereum.t.sol
+++ b/test/marketplace/DecentralandMarketplaceEthereum.t.sol
@@ -61,7 +61,6 @@ abstract contract DecentralandMarketplaceEthereumTests is Test {
     function setUp() public virtual {
         uint256 forkId = vm.createFork("https://rpc.decentraland.org/mainnet", 19755898); // Apr-28-2024 07:27:59 PM +UTC
         vm.selectFork(forkId);
-        vm.chainId(31337);
 
         signer = vm.createWallet("signer");
         other = 0x79c63172C7B01A8a5B074EF54428a452E0794E7A;
@@ -1005,6 +1004,10 @@ contract ExampleTests is DecentralandMarketplaceEthereumTests {
         assertEq(estate.ownerOf(estateTokenId), signer.addr);
         assertEq(land.ownerOf(landTokenId), other);
         assertEq(names.ownerOf(nameTokenId), other);
+
+        // The signature was created on a local network with chainId 31337
+        // To prevent the test from failing, we need to simulate block.chainid to be the same
+        vm.chainId(31337);
 
         vm.prank(other);
         marketplace.accept(trades);

--- a/test/marketplace/DecentralandMarketplaceEthereum.t.sol
+++ b/test/marketplace/DecentralandMarketplaceEthereum.t.sol
@@ -87,7 +87,7 @@ abstract contract DecentralandMarketplaceEthereumTests is Test {
     }
 }
 
-contract UnsupportedAssetTypeTests is DecentralandMarketplaceEthereumTests {
+contract UnsupportedAssetTypeTestsEthereum is DecentralandMarketplaceEthereumTests {
     error UnsupportedAssetType(uint256 _assetType);
 
     function test_RevertsIfAssetTypeIsInvalid() public {
@@ -104,7 +104,7 @@ contract UnsupportedAssetTypeTests is DecentralandMarketplaceEthereumTests {
     }
 }
 
-contract TransferERC20Tests is DecentralandMarketplaceEthereumTests {
+contract TransferERC20TestsEthereum is DecentralandMarketplaceEthereumTests {
     IERC20 erc20;
     uint256 erc20Sent;
     address erc20OriginalHolder;
@@ -233,7 +233,7 @@ contract TransferERC20Tests is DecentralandMarketplaceEthereumTests {
     }
 }
 
-contract TransferUsdPeggedManaTests is DecentralandMarketplaceEthereumTests {
+contract TransferUsdPeggedManaTestsEthereum is DecentralandMarketplaceEthereumTests {
     IERC20 erc20;
     address erc20OriginalHolder;
 
@@ -390,7 +390,7 @@ contract TransferUsdPeggedManaTests is DecentralandMarketplaceEthereumTests {
     }
 }
 
-contract TransferERC721Tests is DecentralandMarketplaceEthereumTests {
+contract TransferERC721TestsEthereum is DecentralandMarketplaceEthereumTests {
     IERC721 erc721;
     uint256 erc721TokenId;
     address erc721OriginalHolder;
@@ -640,7 +640,7 @@ contract TransferComposableTokenTests is DecentralandMarketplaceEthereumTests {
     }
 }
 
-contract UpdateFeeCollectorTests is DecentralandMarketplaceEthereumTests {
+contract UpdateFeeCollectorTestsEthereum is DecentralandMarketplaceEthereumTests {
     event FeeCollectorUpdated(address indexed _caller, address indexed _feeCollector);
 
     function test_RevertsIfCallerIsNotTheOwner() public {
@@ -658,7 +658,7 @@ contract UpdateFeeCollectorTests is DecentralandMarketplaceEthereumTests {
     }
 }
 
-contract UpdateFeeRateTests is DecentralandMarketplaceEthereumTests {
+contract UpdateFeeRateTestsEthereum is DecentralandMarketplaceEthereumTests {
     event FeeRateUpdated(address indexed _caller, uint256 _feeRate);
 
     function test_RevertsIfCallerIsNotTheOwner() public {

--- a/test/marketplace/Marketplace.t.sol
+++ b/test/marketplace/Marketplace.t.sol
@@ -318,7 +318,7 @@ contract CancelSignatureTests is MarketplaceTests {
 }
 
 contract AcceptTests is MarketplaceTests {
-    event Traded(address indexed _caller, bytes32 indexed _signature);
+    event Traded(address indexed _caller, bytes32 indexed _signature, MarketplaceHarness.Trade _trade);
 
     error UsedTradeId();
     error NotEffective();
@@ -887,7 +887,7 @@ contract AcceptTests is MarketplaceTests {
 
         vm.prank(other);
         vm.expectEmit(address(marketplace));
-        emit Traded(other, keccak256(trades[0].signature));
+        emit Traded(other, keccak256(trades[0].signature), trades[0]);
         marketplace.accept(trades);
     }
 }


### PR DESCRIPTION
- Added Trade to Traded event
- Added Coupon to CouponApplied event
- Updated test contract names so `forge snapshot` could work correctly (Test contracts with the same name made the gas snapshots to have conflicts)
- Fixed setup that was breaking the `forge test --gas-report` command