### PR TITLE
fix: Deny and Revoke Changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,5 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv
+          forge coverage --no-match-coverage "(test\/|src\/mocks\/|script\/)" -vvv
         id: test

--- a/src/credits/CreditsManagerPolygon.sol
+++ b/src/credits/CreditsManagerPolygon.sol
@@ -346,12 +346,18 @@ contract CreditsManagerPolygon is AccessControl, Pausable, ReentrancyGuard, Nati
         emit CustomExternalCallAllowed(_msgSender(), _target, _selector, _allowed);
     }
 
-    /// @notice Revokes a custom external call.
-    /// @param _hashedCustomExternalCallSignature The hash of the custom external call signature.
-    function revokeCustomExternalCall(bytes32 _hashedCustomExternalCallSignature) external onlyRole(EXTERNAL_CALL_REVOKER_ROLE) {
-        usedCustomExternalCallSignature[_hashedCustomExternalCallSignature] = true;
+    /// @notice Revokes custom external call signatures.
+    /// @param _customExternalCalls An array of hashed custom external call signatures.
+    function revokeCustomExternalCall(bytes32[] calldata _customExternalCalls) external onlyRole(EXTERNAL_CALL_REVOKER_ROLE) {
+        address sender = _msgSender();
 
-        emit CustomExternalCallRevoked(_msgSender(), _hashedCustomExternalCallSignature);
+        for (uint256 i = 0; i < _customExternalCalls.length; i++) {
+            bytes32 customExternalCall = _customExternalCalls[i];
+
+            usedCustomExternalCallSignature[customExternalCall] = true;
+
+            emit CustomExternalCallRevoked(sender, customExternalCall);
+        }
     }
 
     /// @notice Use credits to pay for external calls that transfer MANA.

--- a/src/credits/CreditsManagerPolygon.sol
+++ b/src/credits/CreditsManagerPolygon.sol
@@ -285,11 +285,17 @@ contract CreditsManagerPolygon is AccessControl, Pausable, ReentrancyGuard, Nati
     }
 
     /// @notice Revokes a credit.
-    /// @param _credit The hash of the credit signature.
-    function revokeCredit(bytes32 _credit) external onlyRole(CREDITS_REVOKER_ROLE) {
-        isRevoked[_credit] = true;
+    /// @param _credits The hash of the credit signatures to be revoked.
+    function revokeCredits(bytes32[] calldata _credits) external onlyRole(CREDITS_REVOKER_ROLE) {
+        address sender = _msgSender();
 
-        emit CreditRevoked(_msgSender(), _credit);
+        for (uint256 i = 0; i < _credits.length; i++) {
+            bytes32 credit = _credits[i];
+
+            isRevoked[credit] = true;
+
+            emit CreditRevoked(sender, credit);
+        }
     }
 
     /// @notice Update the maximum amount of MANA that can be credited per hour.

--- a/test/credits/CreditsManagerPolygon.core.t.sol
+++ b/test/credits/CreditsManagerPolygon.core.t.sol
@@ -136,27 +136,47 @@ contract CreditsManagerPolygonCoreTest is CreditsManagerPolygonTestBase {
         assertTrue(creditsManager.isDenied(users[1]));
     }
 
-    function test_revokeCredit_RevertsWhenNotRevoker() public {
+    function test_revokeCredits_RevertsWhenNotRevoker() public {
+        bytes32[] memory credits = new bytes32[](1);
+        credits[0] = bytes32(0);
         vm.expectRevert(
             abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), creditsManager.CREDITS_REVOKER_ROLE())
         );
-        creditsManager.revokeCredit(bytes32(0));
+        creditsManager.revokeCredits(credits);
     }
 
-    function test_revokeCredit_WhenRevoker() public {
+    function test_revokeCredits_WhenRevoker() public {
+        bytes32[] memory credits = new bytes32[](1);
+        credits[0] = bytes32(0);
         vm.expectEmit(address(creditsManager));
-        emit CreditRevoked(creditsRevoker, bytes32(0));
+        emit CreditRevoked(creditsRevoker, credits[0]);
         vm.prank(creditsRevoker);
-        creditsManager.revokeCredit(bytes32(0));
-        assertTrue(creditsManager.isRevoked(bytes32(0)));
+        creditsManager.revokeCredits(credits);
+        assertTrue(creditsManager.isRevoked(credits[0]));
     }
 
-    function test_revokeCredit_WhenOwner() public {
+    function test_revokeCredits_WhenOwner() public {
+        bytes32[] memory credits = new bytes32[](1);
+        credits[0] = bytes32(0);
         vm.expectEmit(address(creditsManager));
-        emit CreditRevoked(owner, bytes32(0));
+        emit CreditRevoked(owner, credits[0]);
         vm.prank(owner);
-        creditsManager.revokeCredit(bytes32(0));
-        assertTrue(creditsManager.isRevoked(bytes32(0)));
+        creditsManager.revokeCredits(credits);
+        assertTrue(creditsManager.isRevoked(credits[0]));
+    }
+
+    function test_revokeCredits_RevokeMultiple() public {
+        bytes32[] memory credits = new bytes32[](2);
+        credits[0] = bytes32(0);
+        credits[1] = bytes32(uint256(1));
+        vm.expectEmit(address(creditsManager));
+        emit CreditRevoked(owner, credits[0]);
+        vm.expectEmit(address(creditsManager));
+        emit CreditRevoked(owner, credits[1]);
+        vm.prank(owner);
+        creditsManager.revokeCredits(credits);
+        assertTrue(creditsManager.isRevoked(credits[0]));
+        assertTrue(creditsManager.isRevoked(credits[1]));
     }
 
     function test_updateMaxManaCreditedPerHour_RevertsWhenNotOwner() public {

--- a/test/credits/CreditsManagerPolygon.core.t.sol
+++ b/test/credits/CreditsManagerPolygon.core.t.sol
@@ -69,7 +69,9 @@ contract CreditsManagerPolygonCoreTest is CreditsManagerPolygonTestBase {
     }
 
     function test_denyUsers_RevertsWhenNotDenier() public {
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), creditsManager.USER_DENIER_ROLE()));
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), creditsManager.USER_DENIER_ROLE())
+        );
         address[] memory users = new address[](1);
         users[0] = address(this);
         bool[] memory areDenied = new bool[](1);
@@ -251,30 +253,46 @@ contract CreditsManagerPolygonCoreTest is CreditsManagerPolygonTestBase {
     }
 
     function test_revokeCustomExternalCall_RevertsWhenNotCustomExternalCallRevoker() public {
+        bytes32[] memory customExternalCalls = new bytes32[](1);
+        customExternalCalls[0] = bytes32(0);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), creditsManager.EXTERNAL_CALL_REVOKER_ROLE()
             )
         );
-        creditsManager.revokeCustomExternalCall(bytes32(0));
+        creditsManager.revokeCustomExternalCall(customExternalCalls);
     }
 
     function test_revokeCustomExternalCall_WhenCustomExternalCallRevoker() public {
+        bytes32[] memory customExternalCalls = new bytes32[](1);
+        customExternalCalls[0] = bytes32(0);
         vm.expectEmit(address(creditsManager));
-        emit CustomExternalCallRevoked(customExternalCallRevoker, bytes32(0));
+        emit CustomExternalCallRevoked(customExternalCallRevoker, customExternalCalls[0]);
         vm.prank(customExternalCallRevoker);
-        creditsManager.revokeCustomExternalCall(bytes32(0));
-
-        assertTrue(creditsManager.usedCustomExternalCallSignature(bytes32(0)));
+        creditsManager.revokeCustomExternalCall(customExternalCalls);
+        assertTrue(creditsManager.usedCustomExternalCallSignature(customExternalCalls[0]));
     }
 
     function test_revokeCustomExternalCall_WhenOwner() public {
+        bytes32[] memory customExternalCalls = new bytes32[](1);
+        customExternalCalls[0] = bytes32(0);
         vm.expectEmit(address(creditsManager));
-        emit CustomExternalCallRevoked(owner, bytes32(0));
+        emit CustomExternalCallRevoked(owner, customExternalCalls[0]);
         vm.prank(owner);
-        creditsManager.revokeCustomExternalCall(bytes32(0));
+        creditsManager.revokeCustomExternalCall(customExternalCalls);
+        assertTrue(creditsManager.usedCustomExternalCallSignature(customExternalCalls[0]));
+    }
 
-        assertTrue(creditsManager.usedCustomExternalCallSignature(bytes32(0)));
+    function test_revokeCustomExternalCall_RevokesMultiple() public {
+        bytes32[] memory customExternalCalls = new bytes32[](2);
+        customExternalCalls[0] = bytes32(0);
+        customExternalCalls[1] = bytes32(uint256(1));
+        vm.expectEmit(address(creditsManager));
+        emit CustomExternalCallRevoked(owner, customExternalCalls[0]);
+        vm.prank(owner);
+        creditsManager.revokeCustomExternalCall(customExternalCalls);
+        assertTrue(creditsManager.usedCustomExternalCallSignature(customExternalCalls[0]));
+        assertTrue(creditsManager.usedCustomExternalCallSignature(customExternalCalls[1]));
     }
 
     function test_withdrawERC20_RevertsWhenNotOwner() public {

--- a/test/credits/CreditsManagerPolygon.core.t.sol
+++ b/test/credits/CreditsManagerPolygon.core.t.sol
@@ -68,7 +68,7 @@ contract CreditsManagerPolygonCoreTest is CreditsManagerPolygonTestBase {
         vm.stopPrank();
     }
 
-    function test_denyUser_RevertsWhenNotDenier() public {
+    function test_denyUsers_RevertsWhenNotDenier() public {
         vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), creditsManager.USER_DENIER_ROLE()));
         address[] memory users = new address[](1);
         users[0] = address(this);
@@ -77,55 +77,63 @@ contract CreditsManagerPolygonCoreTest is CreditsManagerPolygonTestBase {
         creditsManager.denyUsers(users, areDenied);
     }
 
-    function test_denyUser_WhenDenier() public {
-        vm.expectEmit(address(creditsManager));
-        emit UserDenied(userDenier, address(this), true);
+    function test_denyUsers_WhenDenier() public {
         address[] memory users = new address[](1);
         users[0] = address(this);
         bool[] memory areDenied = new bool[](1);
         areDenied[0] = true;
+        vm.expectEmit(address(creditsManager));
+        emit UserDenied(userDenier, users[0], areDenied[0]);
         vm.prank(userDenier);
         creditsManager.denyUsers(users, areDenied);
         assertTrue(creditsManager.isDenied(address(this)));
     }
 
-    function test_denyUser_WhenOwner() public {
-        vm.expectEmit(address(creditsManager));
-        emit UserDenied(owner, address(this), true);
+    function test_denyUsers_WhenOwner() public {
         address[] memory users = new address[](1);
         users[0] = address(this);
         bool[] memory areDenied = new bool[](1);
         areDenied[0] = true;
+        vm.expectEmit(address(creditsManager));
+        emit UserDenied(owner, users[0], areDenied[0]);
         vm.prank(owner);
         creditsManager.denyUsers(users, areDenied);
         assertTrue(creditsManager.isDenied(address(this)));
     }
 
-    function test_denyUser_AllowsUser() public {
+    function test_denyUsers_AllowsUser() public {
         address[] memory users = new address[](1);
         users[0] = address(this);
         bool[] memory areDenied = new bool[](1);
         areDenied[0] = true;
+        vm.expectEmit(address(creditsManager));
+        emit UserDenied(owner, users[0], areDenied[0]);
         vm.prank(owner);
         creditsManager.denyUsers(users, areDenied);
         assertTrue(creditsManager.isDenied(address(this)));
         areDenied[0] = false;
+        vm.expectEmit(address(creditsManager));
+        emit UserDenied(owner, users[0], areDenied[0]);
         vm.prank(owner);
         creditsManager.denyUsers(users, areDenied);
         assertFalse(creditsManager.isDenied(address(this)));
     }
 
-    function test_denyUser_DeniesMultipleUsers() public {
+    function test_denyUsers_DeniesMultipleUsers() public {
         address[] memory users = new address[](2);
         users[0] = address(1);
         users[1] = address(2);
         bool[] memory areDenied = new bool[](2);
         areDenied[0] = true;
         areDenied[1] = true;
+        vm.expectEmit(address(creditsManager));
+        emit UserDenied(owner, users[0], areDenied[0]);
+        vm.expectEmit(address(creditsManager));
+        emit UserDenied(owner, users[1], areDenied[1]);
         vm.prank(owner);
         creditsManager.denyUsers(users, areDenied);
-        assertTrue(creditsManager.isDenied(address(1)));
-        assertTrue(creditsManager.isDenied(address(2)));
+        assertTrue(creditsManager.isDenied(users[0]));
+        assertTrue(creditsManager.isDenied(users[1]));
     }
 
     function test_revokeCredit_RevertsWhenNotRevoker() public {

--- a/test/credits/CreditsManagerPolygon.useCredits.customExternalCall.t.sol
+++ b/test/credits/CreditsManagerPolygon.useCredits.customExternalCall.t.sol
@@ -894,7 +894,7 @@ contract CreditsManagerPolygonUseCreditsCustomExternalCallTest is CreditsManager
         bytes32[] memory revokedCredits = new bytes32[](1);
         revokedCredits[0] = keccak256(creditsSignatures[0]);
         vm.prank(owner);
-        creditsManager.revokeCredits(revokedCredits);
+        creditsManager.revokeCreditSignatures(revokedCredits);
 
         MockExternalCallTarget externalCallTarget = new MockExternalCallTarget(creditsManager, IERC20(mana), 100 ether);
 

--- a/test/credits/CreditsManagerPolygon.useCredits.customExternalCall.t.sol
+++ b/test/credits/CreditsManagerPolygon.useCredits.customExternalCall.t.sol
@@ -891,8 +891,10 @@ contract CreditsManagerPolygonUseCreditsCustomExternalCallTest is CreditsManager
 
         creditsSignatures[0] = abi.encodePacked(r, s, v);
 
+        bytes32[] memory revokedCredits = new bytes32[](1);
+        revokedCredits[0] = keccak256(creditsSignatures[0]);
         vm.prank(owner);
-        creditsManager.revokeCredit(keccak256(creditsSignatures[0]));
+        creditsManager.revokeCredits(revokedCredits);
 
         MockExternalCallTarget externalCallTarget = new MockExternalCallTarget(creditsManager, IERC20(mana), 100 ether);
 

--- a/test/credits/CreditsManagerPolygon.useCredits.customExternalCall.t.sol
+++ b/test/credits/CreditsManagerPolygon.useCredits.customExternalCall.t.sol
@@ -821,7 +821,11 @@ contract CreditsManagerPolygonUseCreditsCustomExternalCallTest is CreditsManager
 
     function test_useCredits_RevertsWhenUserIsDenied() public {
         vm.prank(userDenier);
-        creditsManager.denyUser(address(this));
+        address[] memory users = new address[](1);
+        users[0] = address(this);
+        bool[] memory areDenied = new bool[](1);
+        areDenied[0] = true;
+        creditsManager.denyUsers(users, areDenied);
 
         CreditsManagerPolygon.Credit[] memory credits = new CreditsManagerPolygon.Credit[](1);
 

--- a/test/credits/utils/CreditsManagerPolygonTestBase.sol
+++ b/test/credits/utils/CreditsManagerPolygonTestBase.sol
@@ -43,8 +43,7 @@ contract CreditsManagerPolygonTestBase is Test, IERC721Receiver {
     address internal seller;
     uint256 internal sellerPk;
 
-    event UserDenied(address indexed _sender, address indexed _user);
-    event UserAllowed(address indexed _sender, address indexed _user);
+    event UserDenied(address indexed _sender, address indexed _user, bool _isDenied);
     event CreditRevoked(address indexed _sender, bytes32 indexed _creditId);
     event ERC20Withdrawn(address indexed _sender, address indexed _token, uint256 _amount, address indexed _to);
     event ERC721Withdrawn(address indexed _sender, address indexed _token, uint256 _tokenId, address indexed _to);


### PR DESCRIPTION
- Revoke accepts multiple credits
- Allow is removed
- Deny accepts multiple users
- Deny receives a bool array to deny or allow users
- Denier role can now both deny and allow, same as owner
- Revoke external calls accepts multiple signatures
- Rename revoke functions
- Make functions callable by onwer + other role more explicit